### PR TITLE
🔖 Prepare release of `2025.12.23`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on a mixture of [Keep a Changelog] and [Common Changelog].
 
 ## [Unreleased]
 
+## [2025.12.23]
+
+### Distribution
+
+- LLVM commit: `f8cb7987c64dcffb72414a40560055cb717dbf74` ([same as Xanadu's PennyLane Catalyst `v0.13.0`](https://github.com/PennyLaneAI/catalyst/blob/afb608306603b6269e50f008f6215df89feb23c0/doc/releases/changelog-0.13.0.md?plain=1#L440))
+
 ## [2025.12.22]
 
 _This is the initial release of the `portable-mlir-toolchain` project._
@@ -22,7 +28,8 @@ _This is the initial release of the `portable-mlir-toolchain` project._
 
 <!-- Version links -->
 
-[unreleased]: https://github.com/munich-quantum-software/portable-mlir-toolchain/compare/2025.12.22...HEAD
+[unreleased]: https://github.com/munich-quantum-software/portable-mlir-toolchain/compare/2025.12.23...HEAD
+[2025.12.23]: https://github.com/munich-quantum-software/portable-mlir-toolchain/releases/tag/2025.12.23
 [2025.12.22]: https://github.com/munich-quantum-software/portable-mlir-toolchain/releases/tag/2025.12.22
 
 <!-- PR links -->


### PR DESCRIPTION
This PR prepares the release of `2025.12.23`, which distributes MLIR built with [`f8cb798`](https://github.com/llvm/llvm-project/commit/f8cb7987c64dcffb72414a40560055cb717dbf74).