### PR TITLE
🔖 Prepare release of `2026.04.14`

### DIFF
--- a/.github/workflows/build-mlir-linux-runner.yml
+++ b/.github/workflows/build-mlir-linux-runner.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       llvm-project-ref:
-        description: "llvm-project ref or tag (e.g., llvmorg-22.1.0)"
+        description: "llvm-project ref or tag (e.g., llvmorg-22.1.3)"
         required: true
         type: string
       runs-on:
@@ -17,8 +17,8 @@ on:
         required: false
         type: string
       mold-version:
-        description: "mold version (e.g., 2.40.4)"
-        default: "2.40.4"
+        description: "mold version (e.g., 2.41.0)"
+        default: "2.41.0"
         required: false
         type: string
 

--- a/.github/workflows/build-mlir-linux.yml
+++ b/.github/workflows/build-mlir-linux.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       llvm-project-ref:
-        description: "llvm-project ref or tag (e.g., llvmorg-22.1.0)"
+        description: "llvm-project ref or tag (e.g., llvmorg-22.1.3)"
         required: true
         type: string
 

--- a/.github/workflows/build-mlir-macos-runner.yml
+++ b/.github/workflows/build-mlir-macos-runner.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       llvm-project-ref:
-        description: "llvm-project ref or tag (e.g., llvmorg-22.1.0)"
+        description: "llvm-project ref or tag (e.g., llvmorg-22.1.3)"
         required: true
         type: string
       runs-on:

--- a/.github/workflows/build-mlir-macos.yml
+++ b/.github/workflows/build-mlir-macos.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       llvm-project-ref:
-        description: "llvm-project ref or tag (e.g., llvmorg-22.1.0)"
+        description: "llvm-project ref or tag (e.g., llvmorg-22.1.3)"
         required: true
         type: string
 

--- a/.github/workflows/build-mlir-windows-runner.yml
+++ b/.github/workflows/build-mlir-windows-runner.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       llvm-project-ref:
-        description: "llvm-project ref or tag (e.g., llvmorg-22.1.0)"
+        description: "llvm-project ref or tag (e.g., llvmorg-22.1.3)"
         required: true
         type: string
       runs-on:

--- a/.github/workflows/build-mlir-windows.yml
+++ b/.github/workflows/build-mlir-windows.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       llvm-project-ref:
-        description: "llvm-project ref or tag (e.g., llvmorg-22.1.0)"
+        description: "llvm-project ref or tag (e.g., llvmorg-22.1.3)"
         required: true
         type: string
 

--- a/.github/workflows/build-portable-mlir-toolchain.yml
+++ b/.github/workflows/build-portable-mlir-toolchain.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       llvm-project-ref:
-        description: "llvm-project ref or tag (e.g., llvmorg-22.1.0)"
+        description: "llvm-project ref or tag (e.g., llvmorg-22.1.3)"
         required: true
         type: string
       release:
@@ -12,7 +12,7 @@ on:
         required: true
         type: boolean
       release-tag:
-        description: "Tag for the GitHub release (e.g., 2025.12.22)"
+        description: "Tag for the GitHub release (e.g., 2026.04.14)"
         required: true
         type: string
       release-notes:
@@ -74,21 +74,21 @@ jobs:
     if: fromJson(needs.change-detection.outputs.run-linux)
     uses: ./.github/workflows/build-mlir-linux.yml
     with:
-      llvm-project-ref: ${{ inputs.llvm-project-ref || 'llvmorg-22.1.0' }}
+      llvm-project-ref: ${{ inputs.llvm-project-ref || 'llvmorg-22.1.3' }}
 
   macos:
     needs: change-detection
     if: fromJson(needs.change-detection.outputs.run-macos)
     uses: ./.github/workflows/build-mlir-macos.yml
     with:
-      llvm-project-ref: ${{ inputs.llvm-project-ref || 'llvmorg-22.1.0' }}
+      llvm-project-ref: ${{ inputs.llvm-project-ref || 'llvmorg-22.1.3' }}
 
   windows:
     needs: change-detection
     if: fromJson(needs.change-detection.outputs.run-windows)
     uses: ./.github/workflows/build-mlir-windows.yml
     with:
-      llvm-project-ref: ${{ inputs.llvm-project-ref || 'llvmorg-22.1.0' }}
+      llvm-project-ref: ${{ inputs.llvm-project-ref || 'llvmorg-22.1.3' }}
 
   # this job does nothing and is only used for branch protection
   required-checks-pass:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on a mixture of [Keep a Changelog] and [Common Changelog].
 
 ## [Unreleased]
 
+## [2026.04.14]
+
+### Distribution
+
+- LLVM tag: `llvmorg-22.1.3`
+- zstd version: `1.5.7`
+- mold version: `2.41.0`
+
 ## [2026.03.29]
 
 ### Distribution
@@ -139,7 +147,8 @@ _This is the initial release of the `portable-mlir-toolchain` project._
 
 <!-- Version links -->
 
-[unreleased]: https://github.com/munich-quantum-software/portable-mlir-toolchain/compare/2026.03.29...HEAD
+[unreleased]: https://github.com/munich-quantum-software/portable-mlir-toolchain/compare/2026.04.14...HEAD
+[2026.04.14]: https://github.com/munich-quantum-software/portable-mlir-toolchain/releases/tag/2026.04.14
 [2026.03.29]: https://github.com/munich-quantum-software/portable-mlir-toolchain/releases/tag/2026.03.29
 [2026.03.18]: https://github.com/munich-quantum-software/portable-mlir-toolchain/releases/tag/2026.03.18
 [2026.03.09]: https://github.com/munich-quantum-software/portable-mlir-toolchain/releases/tag/2026.03.09

--- a/scripts/toolchain/linux/build-mold.sh
+++ b/scripts/toolchain/linux/build-mold.sh
@@ -25,7 +25,7 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 # shellcheck source=./common.sh
 source "$SCRIPT_DIR/common.sh"
 
-MOLD_VERSION="2.40.4"
+MOLD_VERSION="2.41.0"
 while getopts ":z:a:v:" opt; do
   case "$opt" in
     z) ZSTD_ARCHIVE_PATH="$OPTARG" ;;

--- a/scripts/toolchain/linux/in-container.sh
+++ b/scripts/toolchain/linux/in-container.sh
@@ -39,7 +39,7 @@ set -euo pipefail
 source "$(dirname -- "${BASH_SOURCE[0]}")/../common.sh"
 
 ZSTD_VERSION="${ZSTD_VERSION:-$(cat "$IO_DIR/zstd.version" 2>/dev/null || echo 1.5.7)}"
-MOLD_VERSION="${MOLD_VERSION:-$(cat "$IO_DIR/mold.version" 2>/dev/null || echo 2.40.4)}"
+MOLD_VERSION="${MOLD_VERSION:-$(cat "$IO_DIR/mold.version" 2>/dev/null || echo 2.41.0)}"
 NINJA_VERSION="${NINJA_VERSION:-1.13.0}"
 BUILD_TYPE="${BUILD_TYPE:-Release}"
 


### PR DESCRIPTION
This PR prepares the release of `2026.04.14`, which distributes MLIR built with `llvmorg-22.1.3`. Furthermore, `mold` is updated to version 2.41.0.