### PR TITLE
🔖 Prepare release of `2026.05.18`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on a mixture of [Keep a Changelog] and [Common Changelog].
 
 ## [Unreleased]
 
+## [2026.05.18]
+
+### Distribution
+
+- LLVM tag: `llvmorg-22.1.5`
+- zstd version: `1.5.7`
+- mold version: `2.41.0`
+
 ## [2026.05.16]
 
 ### Distribution
@@ -163,7 +171,8 @@ _This is the initial release of the `portable-mlir-toolchain` project._
 
 <!-- Version links -->
 
-[unreleased]: https://github.com/munich-quantum-software/portable-mlir-toolchain/compare/2026.05.16...HEAD
+[unreleased]: https://github.com/munich-quantum-software/portable-mlir-toolchain/compare/2026.05.18...HEAD
+[2026.05.18]: https://github.com/munich-quantum-software/portable-mlir-toolchain/releases/tag/2026.05.18
 [2026.05.16]: https://github.com/munich-quantum-software/portable-mlir-toolchain/releases/tag/2026.05.16
 [2026.05.13]: https://github.com/munich-quantum-software/portable-mlir-toolchain/releases/tag/2026.05.13
 [2026.04.14]: https://github.com/munich-quantum-software/portable-mlir-toolchain/releases/tag/2026.04.14


### PR DESCRIPTION
This PR prepares the release of `2026.05.18`, which distributes MLIR built with [`llvmorg-22.1.5`](https://github.com/llvm/llvm-project/releases/tag/llvmorg-22.1.5).