### PR TITLE
🔖 Prepare release of `2026.06.09`

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,5 @@
+BasedOnStyle: LLVM
+ColumnLimit: 100
+IncludeBlocks: Regroup
+PointerAlignment: Left
+Standard: c++20

--- a/.cmake-format.yaml
+++ b/.cmake-format.yaml
@@ -1,0 +1,7 @@
+format:
+  line_width: 100
+  keyword_case: "upper"
+  autosort: true
+
+markup:
+  first_comment_is_literal: true

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -15,7 +15,7 @@
   enabledManagers: ["cargo", "github-actions", "npm", "pep621", "pre-commit"],
   lockFileMaintenance: {
     enabled: true,
-    automerge: true
+    automerge: true,
   },
   labels: ["dependencies"],
   schedule: ["every weekend"],
@@ -23,28 +23,28 @@
     {
       matchManagers: ["cargo"],
       addLabels: ["rust"],
-      commitMessagePrefix: "⬆\uFE0F\uD83E\uDD80"
+      commitMessagePrefix: "⬆\uFE0F\uD83E\uDD80",
     },
     {
       matchManagers: ["github-actions"],
       addLabels: ["github-actions"],
-      commitMessagePrefix: "⬆\uFE0F\uD83D\uDC68\u200D\uD83D\uDCBB"
+      commitMessagePrefix: "⬆\uFE0F\uD83D\uDC68\u200D\uD83D\uDCBB",
     },
     {
       matchManagers: ["npm"],
       addLabels: ["javascript"],
-      commitMessagePrefix: "⬆\uFE0F\uD83D\uDCDC"
+      commitMessagePrefix: "⬆\uFE0F\uD83D\uDCDC",
     },
     {
       matchManagers: ["pep621"],
       addLabels: ["python"],
-      commitMessagePrefix: "⬆\uFE0F\uD83D\uDC0D"
+      commitMessagePrefix: "⬆\uFE0F\uD83D\uDC0D",
     },
     {
       matchManagers: ["pre-commit"],
       addLabels: ["pre-commit"],
       commitMessagePrefix: "⬆\uFE0F\uD83E\uDE9D",
-      versioning: "pep440"
+      versioning: "pep440",
     },
     {
       matchUpdateTypes: ["lockFileMaintenance"],
@@ -55,7 +55,7 @@
       groupName: "patch updates",
       groupSlug: "all-patch",
       matchUpdateTypes: ["patch"],
-      automerge: true
+      automerge: true,
     },
-  ]
+  ],
 }

--- a/.github/workflows/build-mlir-windows-runner.yml
+++ b/.github/workflows/build-mlir-windows-runner.yml
@@ -8,7 +8,7 @@ on:
         required: true
         type: string
       runs-on:
-        description: "GitHub runner label (e.g., windows-2025)"
+        description: "GitHub runner label (e.g., windows-2022)"
         required: true
         type: string
       zstd-version:
@@ -27,8 +27,8 @@ permissions:
 
 env:
   CMAKE_BUILD_PARALLEL_LEVEL: 4
-  ZSTD_ARCHIVE_PATH: zstd-${{ inputs.zstd-version }}_${{ inputs.runs-on == 'windows-2025' && 'x86_64-pc-windows-msvc' || 'aarch64-pc-windows-msvc' }}.tar.gz
-  LLD_ARCHIVE_PATH: lld-${{ inputs.llvm-project-ref }}_${{ inputs.runs-on == 'windows-2025' && 'x86_64-pc-windows-msvc' || 'aarch64-pc-windows-msvc' }}.tar.zst
+  ZSTD_ARCHIVE_PATH: zstd-${{ inputs.zstd-version }}_${{ inputs.runs-on == 'windows-2022' && 'x86_64-pc-windows-msvc' || 'aarch64-pc-windows-msvc' }}.tar.gz
+  LLD_ARCHIVE_PATH: lld-${{ inputs.llvm-project-ref }}_${{ inputs.runs-on == 'windows-2022' && 'x86_64-pc-windows-msvc' || 'aarch64-pc-windows-msvc' }}.tar.zst
 
 jobs:
   build-zstd:
@@ -93,7 +93,7 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     name: "${{ inputs.runs-on }}: Build MLIR (Release)"
     env:
-      MLIR_ARCHIVE_PATH: llvm-mlir_${{ inputs.llvm-project-ref }}_${{ inputs.runs-on == 'windows-2025' && 'x86_64-pc-windows-msvc' || 'aarch64-pc-windows-msvc' }}.tar.zst
+      MLIR_ARCHIVE_PATH: llvm-mlir_${{ inputs.llvm-project-ref }}_${{ inputs.runs-on == 'windows-2022' && 'x86_64-pc-windows-msvc' || 'aarch64-pc-windows-msvc' }}.tar.zst
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Free up space on runner
@@ -138,7 +138,7 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     name: "${{ inputs.runs-on }}: Build MLIR (Debug)"
     env:
-      MLIR_ARCHIVE_PATH: llvm-mlir_${{ inputs.llvm-project-ref }}_${{ inputs.runs-on == 'windows-2025' && 'x86_64-pc-windows-msvc' || 'aarch64-pc-windows-msvc' }}_debug.tar.zst
+      MLIR_ARCHIVE_PATH: llvm-mlir_${{ inputs.llvm-project-ref }}_${{ inputs.runs-on == 'windows-2022' && 'x86_64-pc-windows-msvc' || 'aarch64-pc-windows-msvc' }}_debug.tar.zst
       MLIR_SPLIT_PART_SIZE_BYTES: 1900000000
       MLIR_EXPECTED_SPLIT_PARTS: 2
     steps:
@@ -238,7 +238,7 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     name: "${{ inputs.runs-on }}: Test MLIR Installation (Release)"
     env:
-      MLIR_ARCHIVE_PATH: llvm-mlir_${{ inputs.llvm-project-ref }}_${{ inputs.runs-on == 'windows-2025' && 'x86_64-pc-windows-msvc' || 'aarch64-pc-windows-msvc' }}.tar.zst
+      MLIR_ARCHIVE_PATH: llvm-mlir_${{ inputs.llvm-project-ref }}_${{ inputs.runs-on == 'windows-2022' && 'x86_64-pc-windows-msvc' || 'aarch64-pc-windows-msvc' }}.tar.zst
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install the latest version of uv
@@ -271,7 +271,7 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     name: "${{ inputs.runs-on }}: Test MLIR Installation (Debug)"
     env:
-      MLIR_ARCHIVE_PATH: llvm-mlir_${{ inputs.llvm-project-ref }}_${{ inputs.runs-on == 'windows-2025' && 'x86_64-pc-windows-msvc' || 'aarch64-pc-windows-msvc' }}_debug.tar.zst
+      MLIR_ARCHIVE_PATH: llvm-mlir_${{ inputs.llvm-project-ref }}_${{ inputs.runs-on == 'windows-2022' && 'x86_64-pc-windows-msvc' || 'aarch64-pc-windows-msvc' }}_debug.tar.zst
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install the latest version of uv

--- a/.github/workflows/build-mlir-windows.yml
+++ b/.github/workflows/build-mlir-windows.yml
@@ -12,11 +12,11 @@ permissions:
   contents: read
 
 jobs:
-  windows-2025:
+  windows-2022:
     uses: ./.github/workflows/build-mlir-windows-runner.yml
     with:
       llvm-project-ref: ${{ inputs.llvm-project-ref }}
-      runs-on: windows-2025
+      runs-on: windows-2022
 
   windows-11-arm:
     uses: ./.github/workflows/build-mlir-windows-runner.yml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,11 @@
 # To run all pre-commit checks, use:
 #
-#     pre-commit run -a
+#     uvx prek run -a
 #
 # To install pre-commit hooks that run every time you commit:
 #
-#     pre-commit install
+#     uv tool install prek
+#     prek install
 #
 
 ci:
@@ -13,70 +14,74 @@ ci:
   autofix_commit_msg: "🎨 pre-commit fixes"
 
 repos:
-  # Standard hooks
+  ## Standard hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
       - id: check-merge-conflict
-      - id: check-added-large-files
-      - id: check-case-conflict
-      - id: check-docstring-first
-      - id: check-symlinks
-      - id: check-toml
-      - id: check-yaml
-      - id: debug-statements
+        args: [--assume-in-merge]
+        fail_fast: true
+        priority: 0
       - id: end-of-file-fixer
-      - id: mixed-line-ending
-      - id: requirements-txt-fixer
+        priority: 1
       - id: trailing-whitespace
+        priority: 2
 
-  # Handling unwanted unicode characters
-  - repo: https://github.com/sirosen/texthooks
-    rev: 0.7.1
+  ## Check JSON schemata
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.37.2
     hooks:
-      - id: fix-ligatures
-      - id: fix-smartquotes
+      - id: check-github-workflows
+        priority: 0
+      - id: check-readthedocs
+        priority: 0
 
-  # Check for common mistakes
-  - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.10.0
-    hooks:
-      - id: rst-backticks
-      - id: rst-directive-colons
-      - id: rst-inline-touching-normal
-
-  # Check for license headers
-  - repo: https://github.com/emzeat/mz-lictools
-    rev: v2.9.0
-    hooks:
-      - id: license-tools
-
-  # Format configuration files with prettier
-  - repo: https://github.com/rbubley/mirrors-prettier
-    rev: v3.8.3
-    hooks:
-      - id: prettier
-        types_or: [yaml, markdown, html, css, scss, javascript, json]
-
-  # Check for spelling
-  - repo: https://github.com/adhtruong/mirrors-typos
-    rev: v1.47.2
-    hooks:
-      - id: typos
-
-  # Catch common capitalization mistakes
+  ## Check for common capitalization mistakes
   - repo: local
     hooks:
       - id: disallow-caps
         name: Disallow improper capitalization
         language: pygrep
-        entry: PyBind|Numpy|Cmake|CCache|Github|PyTest|Mqt|Tum|MQTopt|MQTref
-        exclude: .pre-commit-config.yaml
+        entry: \b(Nanobind|Numpy|Cmake|CCache|Github|PyTest|Mqt|Tum)\b
+        exclude: ^(\.pre-commit-config\.yaml)$
+        priority: 0
 
-  # Check JSON schemata
-  - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.37.2
+  ## Check for typos
+  - repo: https://github.com/adhtruong/mirrors-typos
+    rev: v1.46.3
     hooks:
-      - id: check-dependabot
-      - id: check-github-workflows
-      - id: check-readthedocs
+      - id: typos
+        priority: 3
+
+  ## Check license headers
+  - repo: https://github.com/emzeat/mz-lictools
+    rev: v2.9.0
+    hooks:
+      - id: license-tools
+        priority: 4
+
+  ## Format configuration files with prettier
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: v3.8.3
+    hooks:
+      - id: prettier
+        types_or: [yaml, markdown, html, css, scss, javascript, json, json5]
+        priority: 5
+
+  ## Format CMake files with cmake-format
+  - repo: https://github.com/cheshirekow/cmake-format-precommit
+    rev: v0.6.13
+    hooks:
+      - id: cmake-format
+        additional_dependencies: [pyyaml]
+        types: [file]
+        files: (\.cmake|CMakeLists.txt)(.in)?$
+        priority: 5
+
+  ## Format C++ files with clang-format
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v22.1.5
+    hooks:
+      - id: clang-format
+        types_or: [c++, c, cuda]
+        priority: 5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ The format is based on a mixture of [Keep a Changelog] and [Common Changelog].
 
 ## [Unreleased]
 
+## [2026.06.08]
+
+### Distribution
+
+- LLVM tag: `llvmorg-22.1.6`
+- zstd version: `1.5.7`
+- mold version: `2.41.0`
+
+### Changed
+
+- 🏁 Use `windows-2022` runner for building to ensure compatibility ([#55]) ([**@burgholzer**])
+
 ## [2026.05.18]
 
 ### Distribution
@@ -171,7 +183,8 @@ _This is the initial release of the `portable-mlir-toolchain` project._
 
 <!-- Version links -->
 
-[unreleased]: https://github.com/munich-quantum-software/portable-mlir-toolchain/compare/2026.05.18...HEAD
+[unreleased]: https://github.com/munich-quantum-software/portable-mlir-toolchain/compare/2026.06.08...HEAD
+[2026.06.08]: https://github.com/munich-quantum-software/portable-mlir-toolchain/releases/tag/2026.06.08
 [2026.05.18]: https://github.com/munich-quantum-software/portable-mlir-toolchain/releases/tag/2026.05.18
 [2026.05.16]: https://github.com/munich-quantum-software/portable-mlir-toolchain/releases/tag/2026.05.16
 [2026.05.13]: https://github.com/munich-quantum-software/portable-mlir-toolchain/releases/tag/2026.05.13
@@ -189,6 +202,7 @@ _This is the initial release of the `portable-mlir-toolchain` project._
 
 <!-- PR links -->
 
+[#55]: https://github.com/munich-quantum-software/portable-mlir-toolchain/pull/55
 [#30]: https://github.com/munich-quantum-software/portable-mlir-toolchain/pull/30
 [#28]: https://github.com/munich-quantum-software/portable-mlir-toolchain/pull/28
 [#13]: https://github.com/munich-quantum-software/portable-mlir-toolchain/pull/13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on a mixture of [Keep a Changelog] and [Common Changelog].
 
 ## [Unreleased]
 
-## [2026.06.08]
+## [2026.06.09]
 
 ### Distribution
 
@@ -183,8 +183,8 @@ _This is the initial release of the `portable-mlir-toolchain` project._
 
 <!-- Version links -->
 
-[unreleased]: https://github.com/munich-quantum-software/portable-mlir-toolchain/compare/2026.06.08...HEAD
-[2026.06.08]: https://github.com/munich-quantum-software/portable-mlir-toolchain/releases/tag/2026.06.08
+[unreleased]: https://github.com/munich-quantum-software/portable-mlir-toolchain/compare/2026.06.09...HEAD
+[2026.06.09]: https://github.com/munich-quantum-software/portable-mlir-toolchain/releases/tag/2026.06.09
 [2026.05.18]: https://github.com/munich-quantum-software/portable-mlir-toolchain/releases/tag/2026.05.18
 [2026.05.16]: https://github.com/munich-quantum-software/portable-mlir-toolchain/releases/tag/2026.05.16
 [2026.05.13]: https://github.com/munich-quantum-software/portable-mlir-toolchain/releases/tag/2026.05.13

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -35,9 +35,5 @@ link_directories(${LLVM_BUILD_LIBRARY_DIR})
 add_definitions(${LLVM_DEFINITIONS})
 
 add_llvm_executable(hello_mlir main.cpp)
-target_link_libraries(hello_mlir PRIVATE
-        MLIRIR
-        MLIRSupport
-        LLVMSupport
-)
+target_link_libraries(hello_mlir PRIVATE MLIRIR MLIRSupport LLVMSupport)
 llvm_update_compile_flags(hello_mlir)

--- a/tests/integration/main.cpp
+++ b/tests/integration/main.cpp
@@ -19,20 +19,21 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/Verifier.h"
+
 #include "llvm/Support/raw_ostream.h"
 
 int main() {
-    mlir::MLIRContext context;
-    mlir::OpBuilder builder(&context);
+  mlir::MLIRContext context;
+  mlir::OpBuilder builder(&context);
 
-    auto loc = builder.getUnknownLoc();
-    auto module = mlir::ModuleOp::create(loc);
+  auto loc = builder.getUnknownLoc();
+  auto module = mlir::ModuleOp::create(loc);
 
-    if (mlir::failed(mlir::verify(module))) {
-        llvm::errs() << "Module verification failed\n";
-        return 1;
-    }
+  if (mlir::failed(mlir::verify(module))) {
+    llvm::errs() << "Module verification failed\n";
+    return 1;
+  }
 
-    llvm::outs() << "MLIR integration test passed!\n";
-    return 0;
+  llvm::outs() << "MLIR integration test passed!\n";
+  return 0;
 }


### PR DESCRIPTION
This PR prepares the release of `2026.06.09`, which distributes MLIR built with [`llvmorg-22.1.6`](https://github.com/llvm/llvm-project/releases/tag/llvmorg-22.1.6). Furthermore, it downgrades the Windows runners to `windows-2022` to ensure compatibility.