### PR TITLE
🔖 Prepare release of `2026.06.10`

### DIFF
--- a/.github/workflows/build-mlir-linux-runner.yml
+++ b/.github/workflows/build-mlir-linux-runner.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       llvm-project-ref:
-        description: "llvm-project ref or tag (e.g., llvmorg-22.1.3)"
+        description: "llvm-project ref or tag (e.g., llvmorg-22.1.7)"
         required: true
         type: string
       runs-on:

--- a/.github/workflows/build-mlir-linux.yml
+++ b/.github/workflows/build-mlir-linux.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       llvm-project-ref:
-        description: "llvm-project ref or tag (e.g., llvmorg-22.1.3)"
+        description: "llvm-project ref or tag (e.g., llvmorg-22.1.7)"
         required: true
         type: string
 

--- a/.github/workflows/build-mlir-macos-runner.yml
+++ b/.github/workflows/build-mlir-macos-runner.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       llvm-project-ref:
-        description: "llvm-project ref or tag (e.g., llvmorg-22.1.3)"
+        description: "llvm-project ref or tag (e.g., llvmorg-22.1.7)"
         required: true
         type: string
       runs-on:

--- a/.github/workflows/build-mlir-macos.yml
+++ b/.github/workflows/build-mlir-macos.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       llvm-project-ref:
-        description: "llvm-project ref or tag (e.g., llvmorg-22.1.3)"
+        description: "llvm-project ref or tag (e.g., llvmorg-22.1.7)"
         required: true
         type: string
 

--- a/.github/workflows/build-mlir-windows-runner.yml
+++ b/.github/workflows/build-mlir-windows-runner.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       llvm-project-ref:
-        description: "llvm-project ref or tag (e.g., llvmorg-22.1.3)"
+        description: "llvm-project ref or tag (e.g., llvmorg-22.1.7)"
         required: true
         type: string
       runs-on:

--- a/.github/workflows/build-mlir-windows.yml
+++ b/.github/workflows/build-mlir-windows.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       llvm-project-ref:
-        description: "llvm-project ref or tag (e.g., llvmorg-22.1.3)"
+        description: "llvm-project ref or tag (e.g., llvmorg-22.1.7)"
         required: true
         type: string
 

--- a/.github/workflows/build-portable-mlir-toolchain.yml
+++ b/.github/workflows/build-portable-mlir-toolchain.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       llvm-project-ref:
-        description: "llvm-project ref or tag (e.g., llvmorg-22.1.3)"
+        description: "llvm-project ref or tag (e.g., llvmorg-22.1.7)"
         required: true
         type: string
       release:
@@ -12,7 +12,7 @@ on:
         required: true
         type: boolean
       release-tag:
-        description: "Tag for the GitHub release (e.g., 2026.04.14)"
+        description: "Tag for the GitHub release (e.g., 2026.06.10)"
         required: true
         type: string
       release-notes:
@@ -74,21 +74,21 @@ jobs:
     if: fromJson(needs.change-detection.outputs.run-linux)
     uses: ./.github/workflows/build-mlir-linux.yml
     with:
-      llvm-project-ref: ${{ inputs.llvm-project-ref || 'llvmorg-22.1.3' }}
+      llvm-project-ref: ${{ inputs.llvm-project-ref || 'llvmorg-22.1.7' }}
 
   macos:
     needs: change-detection
     if: fromJson(needs.change-detection.outputs.run-macos)
     uses: ./.github/workflows/build-mlir-macos.yml
     with:
-      llvm-project-ref: ${{ inputs.llvm-project-ref || 'llvmorg-22.1.3' }}
+      llvm-project-ref: ${{ inputs.llvm-project-ref || 'llvmorg-22.1.7' }}
 
   windows:
     needs: change-detection
     if: fromJson(needs.change-detection.outputs.run-windows)
     uses: ./.github/workflows/build-mlir-windows.yml
     with:
-      llvm-project-ref: ${{ inputs.llvm-project-ref || 'llvmorg-22.1.3' }}
+      llvm-project-ref: ${{ inputs.llvm-project-ref || 'llvmorg-22.1.7' }}
 
   # this job does nothing and is only used for branch protection
   required-checks-pass:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on a mixture of [Keep a Changelog] and [Common Changelog].
 
 ## [Unreleased]
 
+## [2026.06.10]
+
+### Distribution
+
+- LLVM tag: `llvmorg-22.1.7`
+- zstd version: `1.5.7`
+- mold version: `2.41.0`
+
 ## [2026.06.09]
 
 ### Distribution
@@ -18,7 +26,7 @@ The format is based on a mixture of [Keep a Changelog] and [Common Changelog].
 
 ### Changed
 
-- 🏁 Use `windows-2022` runner for building to ensure compatibility ([#55]) ([**@burgholzer**])
+- 🏁 Use `windows-2022` runner for building to ensure compatibility ([#55]) ([**@denialhaag**])
 
 ## [2026.05.18]
 
@@ -183,7 +191,8 @@ _This is the initial release of the `portable-mlir-toolchain` project._
 
 <!-- Version links -->
 
-[unreleased]: https://github.com/munich-quantum-software/portable-mlir-toolchain/compare/2026.06.09...HEAD
+[unreleased]: https://github.com/munich-quantum-software/portable-mlir-toolchain/compare/2026.06.10...HEAD
+[2026.06.10]: https://github.com/munich-quantum-software/portable-mlir-toolchain/releases/tag/2026.06.10
 [2026.06.09]: https://github.com/munich-quantum-software/portable-mlir-toolchain/releases/tag/2026.06.09
 [2026.05.18]: https://github.com/munich-quantum-software/portable-mlir-toolchain/releases/tag/2026.05.18
 [2026.05.16]: https://github.com/munich-quantum-software/portable-mlir-toolchain/releases/tag/2026.05.16


### PR DESCRIPTION
This PR prepares the release of `2026.06.10`, which distributes MLIR built with [`llvmorg-22.1.7`](https://github.com/llvm/llvm-project/releases/tag/llvmorg-22.1.7).