### PR TITLE
🔖 Prepare release of `2026.06.12`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ The format is based on a mixture of [Keep a Changelog] and [Common Changelog].
 
 ### Changed
 
-- 🏁 Disable `LLVM_ENABLE_DIA_SDK` to ensure compatibility ([#57]) ([**@denialhaag**])
+- 🏁 Disable `LLVM_ENABLE_DIA_SDK` to ensure builds are compatible with Visual Studio 2022 and 2026 ([#57]) ([**@denialhaag**])
 
 ## [2026.06.10]
 
@@ -38,7 +38,7 @@ The format is based on a mixture of [Keep a Changelog] and [Common Changelog].
 
 ### Changed
 
-- 🏁 Use `windows-2022` runner for building to ensure compatibility ([#55]) ([**@denialhaag**])
+- 🏁 Use `windows-2022` runner for building to ensure builds are compatible with Visual Studio 2022 and 2026 ([#55]) ([**@denialhaag**])
 
 ## [2026.05.18]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ The format is based on a mixture of [Keep a Changelog] and [Common Changelog].
 
 ## [Unreleased]
 
+## [2026.06.12]
+
+### Distribution
+
+- LLVM tag: `llvmorg-22.1.7`
+- zstd version: `1.5.7`
+- mold version: `2.41.0`
+
+### Changed
+
+- 🏁 Disable `LLVM_ENABLE_DIA_SDK` to ensure compatibility ([#57]) ([**@denialhaag**])
+
 ## [2026.06.10]
 
 ### Distribution
@@ -191,7 +203,8 @@ _This is the initial release of the `portable-mlir-toolchain` project._
 
 <!-- Version links -->
 
-[unreleased]: https://github.com/munich-quantum-software/portable-mlir-toolchain/compare/2026.06.10...HEAD
+[unreleased]: https://github.com/munich-quantum-software/portable-mlir-toolchain/compare/2026.06.12...HEAD
+[2026.06.12]: https://github.com/munich-quantum-software/portable-mlir-toolchain/releases/tag/2026.06.12
 [2026.06.10]: https://github.com/munich-quantum-software/portable-mlir-toolchain/releases/tag/2026.06.10
 [2026.06.09]: https://github.com/munich-quantum-software/portable-mlir-toolchain/releases/tag/2026.06.09
 [2026.05.18]: https://github.com/munich-quantum-software/portable-mlir-toolchain/releases/tag/2026.05.18
@@ -211,6 +224,7 @@ _This is the initial release of the `portable-mlir-toolchain` project._
 
 <!-- PR links -->
 
+[#57]: https://github.com/munich-quantum-software/portable-mlir-toolchain/pull/57
 [#55]: https://github.com/munich-quantum-software/portable-mlir-toolchain/pull/55
 [#30]: https://github.com/munich-quantum-software/portable-mlir-toolchain/pull/30
 [#28]: https://github.com/munich-quantum-software/portable-mlir-toolchain/pull/28

--- a/scripts/toolchain/windows/common.ps1
+++ b/scripts/toolchain/windows/common.ps1
@@ -455,7 +455,6 @@ function Get-LlvmCommonCMakeArgs {
         '-DLLVM_INCLUDE_TESTS=OFF',
         '-DLLVM_INCLUDE_BENCHMARKS=OFF',
         '-DLLVM_ENABLE_ASSERTIONS=ON',
-        '-DLLVM_ENABLE_DIA_SDK=OFF',
         '-DLLVM_ENABLE_LTO=OFF',
         '-DLLVM_ENABLE_RTTI=ON',
         '-DLLVM_ENABLE_LIBXML2=OFF',
@@ -464,7 +463,10 @@ function Get-LlvmCommonCMakeArgs {
         '-DLLVM_INSTALL_UTILS=ON',
         '-DLLVM_OPTIMIZED_TABLEGEN=ON',
         '-DLLVM_ENABLE_WARNINGS=OFF',
-        '-DLLVM_ENABLE_ZSTD=OFF'
+        '-DLLVM_ENABLE_ZSTD=OFF',
+        # DIA SDK creates compatibility issues on Windows
+        # See https://github.com/llvm/llvm-project/issues/86250
+        '-DLLVM_ENABLE_DIA_SDK=OFF'
     )
 
     if ($BuildType -eq 'Debug') {

--- a/scripts/toolchain/windows/common.ps1
+++ b/scripts/toolchain/windows/common.ps1
@@ -455,6 +455,7 @@ function Get-LlvmCommonCMakeArgs {
         '-DLLVM_INCLUDE_TESTS=OFF',
         '-DLLVM_INCLUDE_BENCHMARKS=OFF',
         '-DLLVM_ENABLE_ASSERTIONS=ON',
+        '-DLLVM_ENABLE_DIA_SDK=OFF',
         '-DLLVM_ENABLE_LTO=OFF',
         '-DLLVM_ENABLE_RTTI=ON',
         '-DLLVM_ENABLE_LIBXML2=OFF',


### PR DESCRIPTION
This PR disables `LLVM_ENABLE_DIA_SDK` on Windows, as we are running into compatibility issues (see, e.g., https://github.com/FullStaQD/compiler/pull/78). Furthermore, this PR prepares the release of `2026.06.12`, which redistributes MLIR built with [`llvmorg-22.1.7`](https://github.com/llvm/llvm-project/releases/tag/llvmorg-22.1.7).